### PR TITLE
must first compile with python setup.py build

### DIFF
--- a/README
+++ b/README
@@ -12,6 +12,10 @@ quite a bit in many elegant string algorithms.  Since this is a
 wrapper around strmat.stree, most of the documentation in
 doc/stree.doc should apply.
 
+Installation:
+
+   1. Download
+   2. Compile:  > python setup.py build
 
 Here are the modules included in the SuffixTree package:
 


### PR DESCRIPTION
Added a note so that users know they must first compile this (which compiles the C code into a local library).  Use the command 'python setup.py build'
